### PR TITLE
filter out null elements from normalizeEntries array

### DIFF
--- a/lib/contentful-util.js
+++ b/lib/contentful-util.js
@@ -2,7 +2,7 @@ const { documentToHtmlString } = require('@contentful/rich-text-html-renderer');
 const pkg = require('../package.json');
 
 function normalizeEntries({ contentTypes, entries, defaultLocaleCode, options }) {
-    return entries.map(entry => normalizeEntry({ contentTypes, entry, defaultLocaleCode, options }));
+    return entries.map(entry => normalizeEntry({ contentTypes, entry, defaultLocaleCode, options })).filter(entry => entry);
 }
 
 function normalizeEntry({ contentTypes, entry, defaultLocaleCode, options }) {


### PR DESCRIPTION
While working on a Contentful theme I have had an ongoing issue with my local dev server failing to load because of this error.

```jsx
An error occurred when processing the plugins: Cannot read property '__metadata' of null.
TypeError: Cannot read property '__metadata' of null
    at /Users/rob/work/nextjs/themes/starter-nextjs-contentful-theme/sourcebit.js:74:127
```

## Root Cause

In the themes `sourcebit.js` we attempt to read `page.__metadata.modelName` from the `objects` array but if it contains null elements it will throw a TypeError “Cannot read property '__metadata' of null”

The `sourcebit-source-contentful` module `normalizeEntry()` function is returning null elements back to the normalizedEntries array. The normalizedEntries array should filter out null elements.

In my case, the problem was caused by draft assets in Contentful. 
<img width="1268" alt="Screen Shot 2022-02-16 at 12 02 22 pm" src="https://user-images.githubusercontent.com/1386506/154183684-8ff25805-f744-4918-9394-b1e26f461b5b.png">